### PR TITLE
CMake install target for #15. Close #15.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,3 +109,6 @@ set_target_properties(maskromtool PROPERTIES
 if(QT_VERSION_MAJOR EQUAL 6)
     qt_finalize_executable(maskromtool)
 endif()
+
+# Install targets in relation to ${CMAKE_INSTALL_PREFIX}/
+install(TARGETS maskromtool DESTINATION bin)


### PR DESCRIPTION
Added to support the creation of distribution packages. Here's an example Arch Linux PKGBUILD:

```
pkgname=maskromtool-git
pkgver=r22.4c4e9b6
pkgrel=1
pkgdesc="A CAD tool for extracting bits from mask ROM photographs"
arch=('x86_64')
url="https://github.com/travisgoodspeed/maskromtool"
license=('custom:BeerWare')
makedepends=('cmake')
depends=('qt5-base' 'qt5-charts')
provides=('maskromtool')

source=("${pkgname}::git+https://github.com/travisgoodspeed/maskromtool.git")
sha256sums=('SKIP')

pkgver() {
  cd "${pkgname}"
  printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
}

build() {
  cmake -S "${pkgname}" -B build \
    -DCMAKE_INSTALL_PREFIX=/usr \
    -DCMAKE_BUILD_TYPE=Release
  cmake --build build
}

package() {
  DESTDIR="$pkgdir" cmake --install build
}
```